### PR TITLE
Update colorpalette deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
 		],
 		"require":
 		{
-			"silverstripe/framework": "~3.3",
-			"silverstripe/cms": "~3.3",
+			"silverstripe/framework": "^3.3",
+			"silverstripe/cms": "^3.3",
 			"littlegiant/silverstripe-singleobjectadmin": "*",
 			"ryanpotter/silverstripe-color-field": "*",
-			"heyday/silverstripe-colorpalette": "dev-master"
+			"heyday/silverstripe-colorpalette": "^1.1"
 		}
 }


### PR DESCRIPTION
dev-master of heyday/colorpalette is now only core ^4.0 compatible, this pins the core 3.x version of colorpalette to the 3.x compatible version of brand module.